### PR TITLE
feat: adds delete account functionality to template

### DIFF
--- a/flutter_news_example/api/analysis_options.yaml
+++ b/flutter_news_example/api/analysis_options.yaml
@@ -2,6 +2,7 @@ include: package:very_good_analysis/analysis_options.5.1.0.yaml
 analyzer:
   exclude:
     - build/**
+    - lib/**/*.g.dart
 linter:
   rules:
     file_names: false

--- a/flutter_news_example/lib/app/bloc/app_bloc.dart
+++ b/flutter_news_example/lib/app/bloc/app_bloc.dart
@@ -84,7 +84,6 @@ class AppBloc extends Bloc<AppEvent, AppState> {
       // because the user should not receive any notifications after their
       // account is deleted.
       unawaited(_notificationsRepository.toggleNotifications(enable: false));
-
       await _userRepository.deleteAccount();
     } catch (e) {
       await _userRepository.logOut();

--- a/flutter_news_example/lib/app/bloc/app_bloc.dart
+++ b/flutter_news_example/lib/app/bloc/app_bloc.dart
@@ -85,8 +85,9 @@ class AppBloc extends Bloc<AppEvent, AppState> {
       // account is deleted.
       unawaited(_notificationsRepository.toggleNotifications(enable: false));
       await _userRepository.deleteAccount();
-    } catch (e) {
+    } catch (error, stackTrace) {
       await _userRepository.logOut();
+      addError(error, stackTrace);
     }
   }
 

--- a/flutter_news_example/lib/app/bloc/app_bloc.dart
+++ b/flutter_news_example/lib/app/bloc/app_bloc.dart
@@ -24,6 +24,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     on<AppUserChanged>(_onUserChanged);
     on<AppOnboardingCompleted>(_onOnboardingCompleted);
     on<AppLogoutRequested>(_onLogoutRequested);
+    on<AppDeleteAccountRequested>(_onDeleteAccountRequested);
     on<AppOpened>(_onAppOpened);
 
     _userSubscription = _userRepository.user.listen(_userChanged);
@@ -72,6 +73,21 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     unawaited(_notificationsRepository.toggleNotifications(enable: false));
 
     unawaited(_userRepository.logOut());
+  }
+
+  Future<void> _onDeleteAccountRequested(
+    AppDeleteAccountRequested event,
+    Emitter<AppState> emit,
+  ) async {
+    try {
+      // We are disabling notifications when a user deletes their account
+      // because the user should not receive any notifications after their
+      // account is deleted.
+      unawaited(_notificationsRepository.toggleNotifications(enable: false));
+      await _userRepository.deleteAccount();
+    } catch (e) {
+      await _userRepository.logOut();
+    }
   }
 
   Future<void> _onAppOpened(AppOpened event, Emitter<AppState> emit) async {

--- a/flutter_news_example/lib/app/bloc/app_bloc.dart
+++ b/flutter_news_example/lib/app/bloc/app_bloc.dart
@@ -84,6 +84,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
       // because the user should not receive any notifications after their
       // account is deleted.
       unawaited(_notificationsRepository.toggleNotifications(enable: false));
+
       await _userRepository.deleteAccount();
     } catch (e) {
       await _userRepository.logOut();

--- a/flutter_news_example/lib/app/bloc/app_event.dart
+++ b/flutter_news_example/lib/app/bloc/app_event.dart
@@ -11,6 +11,10 @@ class AppLogoutRequested extends AppEvent {
   const AppLogoutRequested();
 }
 
+class AppDeleteAccountRequested extends AppEvent {
+  const AppDeleteAccountRequested();
+}
+
 class AppUserChanged extends AppEvent {
   const AppUserChanged(this.user);
 

--- a/flutter_news_example/lib/l10n/arb/app_en.arb
+++ b/flutter_news_example/lib/l10n/arb/app_en.arb
@@ -616,5 +616,29 @@
     "description": "Text displayed on the refresh button when a network error occurs.",
     "type": "String",
     "placeholders": {}
+  },
+  "userProfileDeleteAccountButton": "Delete account",
+  "@userProfileDeleteAccountButton": {
+    "description": "User profile delete account button title",
+    "type": "String",
+    "placeholders": {}
+  },
+  "deleteAccountDialogTitle": "ADD YOUR DELETE DIALOG TITLE",
+  "@deleteAccountDialogTitle": {
+    "description": "Delete account dialog title",
+    "type": "String",
+    "placeholders": {}
+  },
+  "deleteAccountDialogSubtitle": "ADD YOUR DELETE DIALOG SUBTITLE",
+  "@deleteAccountDialogSubtitle": {
+    "description": "Delete account dialog subtitle",
+    "type": "String",
+    "placeholders": {}
+  },
+  "deleteAccountDialogCancelButtonText": "Cancel",
+  "@deleteAccountDialogCancelButtonText": {
+    "description": "Delete account dialog cancel button text",
+    "type": "String",
+    "placeholders": {}
   }
 }

--- a/flutter_news_example/lib/l10n/arb/app_en.arb
+++ b/flutter_news_example/lib/l10n/arb/app_en.arb
@@ -617,15 +617,9 @@
     "type": "String",
     "placeholders": {}
   },
-  "userProfileDeleteAccountButton": "Delete account",
-  "@userProfileDeleteAccountButton": {
-    "description": "User profile delete account button title",
-    "type": "String",
-    "placeholders": {}
-  },
-  "deleteAccountDialogTitle": "ADD YOUR DELETE DIALOG TITLE",
-  "@deleteAccountDialogTitle": {
-    "description": "Delete account dialog title",
+  "deleteAccountDialogCancelButtonText": "Cancel",
+  "@deleteAccountDialogCancelButtonText": {
+    "description": "Delete account dialog cancel button text",
     "type": "String",
     "placeholders": {}
   },
@@ -635,9 +629,15 @@
     "type": "String",
     "placeholders": {}
   },
-  "deleteAccountDialogCancelButtonText": "Cancel",
-  "@deleteAccountDialogCancelButtonText": {
-    "description": "Delete account dialog cancel button text",
+  "deleteAccountDialogTitle": "ADD YOUR DELETE DIALOG TITLE",
+  "@deleteAccountDialogTitle": {
+    "description": "Delete account dialog title",
+    "type": "String",
+    "placeholders": {}
+  },
+  "userProfileDeleteAccountButton": "Delete account",
+  "@userProfileDeleteAccountButton": {
+    "description": "User profile delete account button title",
     "type": "String",
     "placeholders": {}
   }

--- a/flutter_news_example/lib/user_profile/view/user_profile_page.dart
+++ b/flutter_news_example/lib/user_profile/view/user_profile_page.dart
@@ -178,6 +178,23 @@ class _UserProfileViewState extends State<UserProfileView>
                       leading: Assets.icons.aboutIcon.svg(),
                       title: l10n.userProfileLegalAboutTitle,
                     ),
+                    Align(
+                      child: AppButton.smallTransparent(
+                        key: const Key('userProfilePage_deleteAccountButton'),
+                        onPressed: () {
+                          showDialog<void>(
+                            context: context,
+                            builder: (BuildContext context) {
+                              return const UserProfileDeleteAccountDialog();
+                            },
+                          );
+                        },
+                        child: Text(
+                          context.l10n.userProfileDeleteAccountButton,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.lg),
                   ],
                 ),
               ),

--- a/flutter_news_example/lib/user_profile/view/user_profile_page.dart
+++ b/flutter_news_example/lib/user_profile/view/user_profile_page.dart
@@ -184,13 +184,12 @@ class _UserProfileViewState extends State<UserProfileView>
                         onPressed: () {
                           showDialog<void>(
                             context: context,
-                            builder: (BuildContext context) {
-                              return const UserProfileDeleteAccountDialog();
-                            },
+                            builder: (_) =>
+                                const UserProfileDeleteAccountDialog(),
                           );
                         },
                         child: Text(
-                          context.l10n.userProfileDeleteAccountButton,
+                          l10n.userProfileDeleteAccountButton,
                         ),
                       ),
                     ),

--- a/flutter_news_example/lib/user_profile/widgets/user_profile_delete_account_dialog.dart
+++ b/flutter_news_example/lib/user_profile/widgets/user_profile_delete_account_dialog.dart
@@ -16,15 +16,9 @@ class UserProfileDeleteAccountDialog extends StatelessWidget {
         l10n.deleteAccountDialogTitle,
         style: Theme.of(context).textTheme.titleLarge,
       ),
-      content: SingleChildScrollView(
-        child: ListBody(
-          children: <Widget>[
-            Text(
-              l10n.deleteAccountDialogSubtitle,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-          ],
-        ),
+      content: Text(
+        l10n.deleteAccountDialogSubtitle,
+        style: Theme.of(context).textTheme.bodyMedium,
       ),
       actions: <Widget>[
         AppButton.smallDarkAqua(

--- a/flutter_news_example/lib/user_profile/widgets/user_profile_delete_account_dialog.dart
+++ b/flutter_news_example/lib/user_profile/widgets/user_profile_delete_account_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:app_ui/app_ui.dart';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_news_example/app/app.dart';
+import 'package:flutter_news_example/l10n/l10n.dart';
+
+class UserProfileDeleteAccountDialog extends StatelessWidget {
+  const UserProfileDeleteAccountDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return AlertDialog(
+      title: Text(
+        l10n.deleteAccountDialogTitle,
+        style: Theme.of(context).textTheme.titleLarge,
+      ),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            Text(
+              l10n.deleteAccountDialogSubtitle,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        AppButton.smallDarkAqua(
+          key: const Key('userProfilePage_cancelDeleteAccountButton'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(l10n.deleteAccountDialogCancelButtonText),
+        ),
+        AppButton.smallRedWine(
+          key: const Key('userProfilePage_deleteAccountButton'),
+          onPressed: () {
+            context.read<AppBloc>().add(const AppDeleteAccountRequested());
+            Navigator.of(context).pop();
+          },
+          child: Text(l10n.userProfileDeleteAccountButton),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_news_example/lib/user_profile/widgets/widgets.dart
+++ b/flutter_news_example/lib/user_profile/widgets/widgets.dart
@@ -1,2 +1,3 @@
 export 'user_profile_button.dart';
+export 'user_profile_delete_account_dialog.dart';
 export 'user_profile_subscribe_box.dart';

--- a/flutter_news_example/packages/authentication_client/authentication_client/lib/src/authentication_client.dart
+++ b/flutter_news_example/packages/authentication_client/authentication_client/lib/src/authentication_client.dart
@@ -101,6 +101,14 @@ class LogOutFailure extends AuthenticationException {
   const LogOutFailure(super.error);
 }
 
+/// {@template delete_account_failure}
+/// Thrown during the delete account process if a failure occurs.
+/// {@endtemplate}
+class DeleteAccountFailure extends AuthenticationException {
+  /// {@macro delete_account_failure}
+  const DeleteAccountFailure(super.error);
+}
+
 /// A generic Authentication Client Interface.
 abstract class AuthenticationClient {
   /// Stream of [AuthenticationUser] which will emit the current user when
@@ -160,4 +168,9 @@ abstract class AuthenticationClient {
   ///
   /// Throws a [LogOutFailure] if an exception occurs.
   Future<void> logOut();
+
+  /// Deletes the current user account.
+  ///
+  /// Throws a [DeleteAccountFailure] if an exception occurs.
+  Future<void> deleteAccount();
 }

--- a/flutter_news_example/packages/authentication_client/authentication_client/test/src/authentication_client_test.dart
+++ b/flutter_news_example/packages/authentication_client/authentication_client/test/src/authentication_client_test.dart
@@ -91,4 +91,11 @@ void main() {
       returnsNormally,
     );
   });
+
+  test('exports DeleteAccountFailure', () {
+    expect(
+      () => DeleteAccountFailure('oops'),
+      returnsNormally,
+    );
+  });
 }

--- a/flutter_news_example/packages/authentication_client/firebase_authentication_client/lib/src/firebase_authentication_client.dart
+++ b/flutter_news_example/packages/authentication_client/firebase_authentication_client/lib/src/firebase_authentication_client.dart
@@ -271,6 +271,23 @@ class FirebaseAuthenticationClient implements AuthenticationClient {
     }
   }
 
+  /// Deletes and signs out the user.
+  @override
+  Future<void> deleteAccount() async {
+    try {
+      final user = _firebaseAuth.currentUser;
+      if (user == null) {
+        throw DeleteAccountFailure(
+          Exception('User is not authenticated'),
+        );
+      }
+
+      await user.delete();
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(DeleteAccountFailure(error), stackTrace);
+    }
+  }
+
   /// Updates the user token in [TokenStorage] if the user is authenticated.
   Future<void> _onUserChanged(AuthenticationUser user) async {
     if (!user.isAnonymous) {

--- a/flutter_news_example/packages/authentication_client/firebase_authentication_client/test/firebase_authentication_client_test.dart
+++ b/flutter_news_example/packages/authentication_client/firebase_authentication_client/test/firebase_authentication_client_test.dart
@@ -596,6 +596,38 @@ void main() {
       });
     });
 
+    group('deleteAccount', () {
+      test('calls deleteAccount', () async {
+        final firebaseUser = MockFirebaseUser();
+        when(firebaseUser.delete).thenAnswer((_) async {});
+        when(() => firebaseAuth.currentUser).thenReturn(firebaseUser);
+
+        await firebaseAuthenticationClient.deleteAccount();
+        verify(() => firebaseAuth.currentUser).called(1);
+        verify(firebaseUser.delete).called(1);
+      });
+
+      test('throws DeleteAccountFailure if current user is null', () async {
+        when(() => firebaseAuth.currentUser).thenReturn(null);
+
+        expect(
+          firebaseAuthenticationClient.deleteAccount(),
+          throwsA(isA<DeleteAccountFailure>()),
+        );
+      });
+
+      test('throws DeleteAccountFailure when deleteAccount throws', () async {
+        final firebaseUser = MockFirebaseUser();
+        when(firebaseUser.delete).thenThrow(Exception());
+        when(() => firebaseAuth.currentUser).thenReturn(firebaseUser);
+
+        expect(
+          firebaseAuthenticationClient.deleteAccount(),
+          throwsA(isA<DeleteAccountFailure>()),
+        );
+      });
+    });
+
     group('user', () {
       const userId = 'mock-uid';
       const email = 'mock-email';

--- a/flutter_news_example/packages/user_repository/lib/src/user_repository.dart
+++ b/flutter_news_example/packages/user_repository/lib/src/user_repository.dart
@@ -211,7 +211,7 @@ class UserRepository {
     }
   }
 
- /// Deletes the current user account.
+  /// Deletes the current user account.
   Future<void> deleteAccount() async {
     try {
       await _authenticationClient.deleteAccount();
@@ -221,6 +221,7 @@ class UserRepository {
       Error.throwWithStackTrace(DeleteAccountFailure(error), stackTrace);
     }
   }
+
   /// Returns the number of times the app was opened.
   Future<int> fetchAppOpenedCount() async {
     try {

--- a/flutter_news_example/packages/user_repository/lib/src/user_repository.dart
+++ b/flutter_news_example/packages/user_repository/lib/src/user_repository.dart
@@ -211,6 +211,16 @@ class UserRepository {
     }
   }
 
+ /// Deletes the current user account.
+  Future<void> deleteAccount() async {
+    try {
+      await _authenticationClient.deleteAccount();
+    } on DeleteAccountFailure {
+      rethrow;
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(DeleteAccountFailure(error), stackTrace);
+    }
+  }
   /// Returns the number of times the app was opened.
   Future<int> fetchAppOpenedCount() async {
     try {

--- a/flutter_news_example/packages/user_repository/test/src/user_repository_test.dart
+++ b/flutter_news_example/packages/user_repository/test/src/user_repository_test.dart
@@ -45,6 +45,8 @@ class FakeLogInWithFacebookCanceled extends Fake
 
 class FakeLogOutFailure extends Fake implements LogOutFailure {}
 
+class FakeDeleteAccountFailure extends Fake implements DeleteAccountFailure {}
+
 class FakeSendLoginEmailLinkFailure extends Fake
     implements SendLoginEmailLinkFailure {}
 
@@ -416,6 +418,29 @@ void main() {
       test('throws LogOutFailure on generic exception', () async {
         when(() => authenticationClient.logOut()).thenThrow(Exception());
         expect(() => userRepository.logOut(), throwsA(isA<LogOutFailure>()));
+      });
+    });
+
+    group('deleteAccount', () {
+      test('calls logOut on AuthenticationClient', () async {
+        when(() => authenticationClient.deleteAccount())
+            .thenAnswer((_) async {});
+        await userRepository.deleteAccount();
+        verify(() => authenticationClient.deleteAccount()).called(1);
+      });
+
+      test('rethrows DeleteAccountFailure', () async {
+        final exception = FakeDeleteAccountFailure();
+        when(() => authenticationClient.deleteAccount()).thenThrow(exception);
+        expect(() => userRepository.deleteAccount(), throwsA(exception));
+      });
+
+      test('throws DeleteAccountFailure on generic exception', () async {
+        when(() => authenticationClient.deleteAccount()).thenThrow(Exception());
+        expect(
+          () => userRepository.deleteAccount(),
+          throwsA(isA<DeleteAccountFailure>()),
+        );
       });
     });
 

--- a/flutter_news_example/pubspec.lock
+++ b/flutter_news_example/pubspec.lock
@@ -256,10 +256,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -949,10 +949,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1488,10 +1488,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.11.0"
   storage:
     dependency: transitive
     description:
@@ -1503,10 +1503,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   stream_transform:
     dependency: "direct main"
     description:
@@ -1543,26 +1543,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.24.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.5.3"
   timing:
     dependency: transitive
     description:
@@ -1781,10 +1781,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1866,5 +1866,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.1.0 <4.0.0"
   flutter: ">=3.13.0"

--- a/flutter_news_example/pubspec.lock
+++ b/flutter_news_example/pubspec.lock
@@ -1866,5 +1866,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.13.0"

--- a/flutter_news_example/pubspec.lock
+++ b/flutter_news_example/pubspec.lock
@@ -256,10 +256,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -949,10 +949,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -1488,10 +1488,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   storage:
     dependency: transitive
     description:
@@ -1503,10 +1503,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: "direct main"
     description:
@@ -1543,26 +1543,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.9"
   timing:
     dependency: transitive
     description:
@@ -1781,10 +1781,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:

--- a/flutter_news_example/test/app/bloc/app_bloc_test.dart
+++ b/flutter_news_example/test/app/bloc/app_bloc_test.dart
@@ -241,6 +241,64 @@ void main() {
       );
     });
 
+    group('AppDeleteAccountRequested', () {
+      setUp(() {
+        when(
+          () => notificationsRepository.toggleNotifications(
+            enable: any(named: 'enable'),
+          ),
+        ).thenAnswer((_) async {});
+
+        when(() => userRepository.deleteAccount()).thenAnswer((_) async {});
+        when(() => userRepository.logOut()).thenAnswer((_) async {});
+      });
+
+      blocTest<AppBloc, AppState>(
+        'calls toggleNotifications off on NotificationsRepository',
+        build: () => AppBloc(
+          userRepository: userRepository,
+          notificationsRepository: notificationsRepository,
+          user: user,
+        ),
+        act: (bloc) => bloc.add(AppDeleteAccountRequested()),
+        verify: (_) {
+          verify(
+            () => notificationsRepository.toggleNotifications(enable: false),
+          ).called(1);
+        },
+      );
+
+      blocTest<AppBloc, AppState>(
+        'calls deleteAccount on UserRepository',
+        build: () => AppBloc(
+          userRepository: userRepository,
+          notificationsRepository: notificationsRepository,
+          user: user,
+        ),
+        act: (bloc) => bloc.add(AppDeleteAccountRequested()),
+        verify: (_) {
+          verify(() => userRepository.deleteAccount()).called(1);
+        },
+      );
+
+      blocTest<AppBloc, AppState>(
+        'calls logOut when deleteAccount on UserRepository fails',
+        setUp: () {
+          when(() => userRepository.deleteAccount()).thenThrow(Exception());
+        },
+        build: () => AppBloc(
+          userRepository: userRepository,
+          notificationsRepository: notificationsRepository,
+          user: user,
+        ),
+        act: (bloc) => bloc.add(AppDeleteAccountRequested()),
+        verify: (_) {
+          verify(() => userRepository.deleteAccount()).called(1);
+          verify(() => userRepository.logOut()).called(1);
+        },
+      );
+    });
+
     group('close', () {
       late StreamController<User> userController;
 

--- a/flutter_news_example/test/app/bloc/app_event_test.dart
+++ b/flutter_news_example/test/app/bloc/app_event_test.dart
@@ -37,6 +37,15 @@ void main() {
       });
     });
 
+    group('AppDeleteAccountRequested', () {
+      test('supports value comparisons', () {
+        expect(
+          AppDeleteAccountRequested(),
+          AppDeleteAccountRequested(),
+        );
+      });
+    });
+
     group('AppOpened', () {
       test('supports value comparisons', () {
         expect(

--- a/flutter_news_example/test/user_profile/view/user_profile_page_test.dart
+++ b/flutter_news_example/test/user_profile/view/user_profile_page_test.dart
@@ -537,6 +537,36 @@ void main() {
           expect(find.byType(NotificationPreferencesPage), findsOneWidget);
         });
       });
+
+      group('shows', () {
+        testWidgets(
+            'UserProfileDeleteAccountDialog '
+            'when tapped on Delete account', (tester) async {
+          await tester.pumpApp(
+            BlocProvider.value(
+              value: userProfileBloc,
+              child: UserProfileView(),
+            ),
+          );
+
+          final deleteAccountButton = find.byKey(
+            Key('userProfilePage_deleteAccountButton'),
+          );
+          await tester.dragUntilVisible(
+            deleteAccountButton,
+            find.byType(UserProfileView),
+            Offset(0, -100),
+            duration: Duration.zero,
+          );
+          await tester.pumpAndSettle();
+
+          await tester.ensureVisible(deleteAccountButton);
+          await tester.tap(deleteAccountButton);
+          await tester.pumpAndSettle();
+
+          expect(find.byType(UserProfileDeleteAccountDialog), findsOneWidget);
+        });
+      });
     });
   });
 }

--- a/flutter_news_example/test/user_profile/widgets/user_profile_delete_account_dialog_test.dart
+++ b/flutter_news_example/test/user_profile/widgets/user_profile_delete_account_dialog_test.dart
@@ -1,0 +1,72 @@
+// ignore_for_file: prefer_const_constructors
+import 'package:flutter/material.dart';
+import 'package:flutter_news_example/app/app.dart';
+import 'package:flutter_news_example/user_profile/user_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockingjay/mockingjay.dart';
+
+import '../../helpers/helpers.dart';
+
+void main() {
+  group('UserProfileDeleteAccountDialog', () {
+    late AppBloc appBloc;
+
+    final cancelButton = find.byKey(
+      const Key('userProfilePage_cancelDeleteAccountButton'),
+    );
+    final deleteAccountButton = find.byKey(
+      const Key('userProfilePage_deleteAccountButton'),
+    );
+
+    setUp(() {
+      appBloc = MockAppBloc();
+    });
+
+    testWidgets('renders cancel and delete account buttons', (tester) async {
+      await tester.pumpApp(
+        UserProfileDeleteAccountDialog(),
+        appBloc: appBloc,
+      );
+
+      expect(cancelButton, findsOneWidget);
+      expect(deleteAccountButton, findsOneWidget);
+    });
+
+    testWidgets('closes dialog when cancel button is pressed', (tester) async {
+      final navigator = MockNavigator();
+      when(navigator.pop).thenAnswer((_) async {});
+
+      await tester.pumpApp(
+        Scaffold(body: UserProfileDeleteAccountDialog()),
+        appBloc: appBloc,
+        navigator: navigator,
+      );
+
+      expect(cancelButton, findsOneWidget);
+      await tester.pumpAndSettle();
+      await tester.tap(cancelButton);
+
+      verify(navigator.pop).called(1);
+    });
+
+    testWidgets(
+        'adds AppDeleteAccountRequested to AppBloc and closes dialog '
+        'when delete account button is pressed', (tester) async {
+      final navigator = MockNavigator();
+      when(navigator.pop).thenAnswer((_) async {});
+
+      await tester.pumpApp(
+        Scaffold(body: UserProfileDeleteAccountDialog()),
+        appBloc: appBloc,
+        navigator: navigator,
+      );
+
+      expect(cancelButton, findsOneWidget);
+      await tester.pumpAndSettle();
+      await tester.tap(deleteAccountButton);
+
+      verify(() => appBloc.add(const AppDeleteAccountRequested())).called(1);
+      verify(navigator.pop).called(1);
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- delete account has become a requirement in most reviews by Apple, so it would be great if it's added by default to the template.

## Screenshots

<img src="https://github.com/elianortega/news_toolkit/assets/54898038/79ca15df-4007-46be-9a8b-5bcaff017d12" width="300"/>

<img src="https://github.com/elianortega/news_toolkit/assets/54898038/f4b4cbb9-9dff-4d03-9f8e-a4d222da2b9f" width="300"/>

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
